### PR TITLE
Support user-provided URI & Fix string printing issues when compiled with clang 

### DIFF
--- a/RequestAADRefreshTokenCpp/main.cpp
+++ b/RequestAADRefreshTokenCpp/main.cpp
@@ -2,6 +2,8 @@
 #include <proofofpossessioncookieinfo.h>
 #include <windows.h>
 
+// compile with Visual Studio or clang -lole32 -s main.cpp -o requestaadrefreshtoken.exe
+
 int main()
 {
 	LPCWSTR uri = L"https://login.microsoftonline.com/";
@@ -38,16 +40,16 @@ int main()
 
 	if (cookieCount == 0)
 	{
-		wprintf(L"No cookies for he URI\n");
+		wprintf(L"No cookies for the URI: %ls\n", uri);
 		return 0;
 	}
 
 	for (DWORD i = 0; i < cookieCount; i++)
 	{
-		wprintf(L"Name: %s\n", cookies[i].name);
-		wprintf(L"Data: %s\n", cookies[i].data);
+		wprintf(L"Name: %ls\n", cookies[i].name);
+		wprintf(L"Data: %ls\n", cookies[i].data);
 		wprintf(L"Flags: %x\n", cookies[i].flags);
-		wprintf(L"P3PHeader: %s\n\n", cookies[i].p3pHeader);
+		wprintf(L"P3PHeader: %ls\n\n", cookies[i].p3pHeader);
 	}
 
 	FreeProofOfPossessionCookieInfoArray(cookies, cookieCount);

--- a/RequestAADRefreshTokenCpp/main.cpp
+++ b/RequestAADRefreshTokenCpp/main.cpp
@@ -4,9 +4,11 @@
 
 // compile with Visual Studio or clang -lole32 -s main.cpp -o requestaadrefreshtoken.exe
 
+#define BUFSIZE 2048
+
 int main()
 {
-	LPCWSTR uri = L"https://login.microsoftonline.com/";
+	wchar_t uri[2048];
 	DWORD cookieCount = 0;
 	ProofOfPossessionCookieInfo* cookies;
 	IProofOfPossessionCookieInfoManager* popCookieManager;
@@ -15,6 +17,16 @@ int main()
 
 	CLSIDFromString(L"{A9927F85-A304-4390-8B23-A75F1C668600}", &CLSID_ProofOfPossessionCookieInfoManager);
 	IIDFromString(L"{CDAECE56-4EDF-43DF-B113-88E4556FA1BB}", &IID_IProofOfPossessionCookieInfoManager);
+
+	memset(uri, 0x00, sizeof(uri));
+
+	if ( argc < 2) {
+		_snwprintf_s(uri, BUFSIZE, BUFSIZE, L"%ls", L"https://login.microsoftonline.com/common/oauth2/authorize");
+	} else {
+		mbstowcs(uri, argv[1], BUFSIZE);
+	}
+
+	wprintf(L"Using URI: %ls\n", uri);
 
 	HRESULT hr = CoInitialize(NULL);
 	if (FAILED(hr))


### PR DESCRIPTION
Fix string printing when compiled with clang - `%s` would only print the first character of the string